### PR TITLE
Fixed preview page font

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -176,6 +176,7 @@ main {
 
 #warning-message {
     font-size: 24px;
+    font-family: 'Montserrat', sans-serif;
     font-weight: bold;
     position: fixed;
     z-index: 9999;


### PR DESCRIPTION
I saw that when the target URL was being previewed, it's CSS modified the `#warning-message`. I fixed it by defining the font that was using in the style.